### PR TITLE
Travis CI build hosts received NFS stale handle errors. Debug this.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   matrix:
     - NETBSD_VERSION=6.0
-    - NETBSD_VERSION=6.0.6
+    - NETBSD_VERSION=6.0.5
     - NETBSD_VERSION=6.1
     - NETBSD_VERSION=6.1.5
     - NETBSD_VERSION=7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       env: NETBSD_VERSION
       script:
         - is_travis_master_push &&
-          dockerhub_set_description madworx/netbsd README.md
+          dockerhub_set_description madworx/netbsd README.md || true
 
 after_success:
   - is_travis_master_push &&


### PR DESCRIPTION
Also: NetBSD 6.0.6 doesn't have pkgsrc(?). 6.0.5 does, however.