### PR TITLE
Fix fdescfs mount location.

### DIFF
--- a/scripts/system-setup.pre.netbsd
+++ b/scripts/system-setup.pre.netbsd
@@ -21,11 +21,11 @@ echo "netbsd"       > etc/myname
 mkdir -p kern proc dev/pts
 
 cat > etc/fstab <<EOF
-192.168.76.2:/bsd  /        nfs    rw          0  0
-/kern              /kern    kernfs rw          0  0
-/proc              /proc    procfs rw          0  0
-fdesc              /dev     fdesc  ro,-o=union 0  0
-ptyfs              /dev/pts ptyfs  rw          0  0
+192.168.76.2:/bsd  /        nfs     rw          0  0
+/kern              /kern    kernfs  rw          0  0
+/proc              /proc    procfs  rw          0  0
+fdesc              /dev/fd  fdescfs rw,-o=union 0  0
+ptyfs              /dev/pts ptyfs   rw          0  0
 EOF
 
 gzip -c netbsd > netbsd.gz


### PR DESCRIPTION
This fixes warnings like the following when trying to call `sort`:
`sort: /dev/stdin: Device not configured`