### PR TITLE
Support newer versions of QEMU by moving from "virtio" netdev -> e1000.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -83,7 +83,7 @@ trap "{ echo \"Shutting down gracefully...\" 1>&2 ; \
                    -boot n \
                    ${ENABLE_KVM} \
                    -serial mon:stdio \
-                   -netdev user,id=mynet0,net=192.168.76.0/24,dhcpstart=192.168.76.9,hostfwd=tcp::${SSH_PORT}-:22,tftp=/bsd,bootfile=pxeboot_ia32_com0.bin,rootpath=/bsd -device virtio,netdev=mynet0 \
+                   -netdev user,id=mynet0,net=192.168.76.0/24,dhcpstart=192.168.76.9,hostfwd=tcp::${SSH_PORT}-:22,tftp=/bsd,bootfile=pxeboot_ia32_com0.bin,rootpath=/bsd -device e1000,netdev=mynet0 \
                    -m ${SYSTEM_MEMORY} -smp ${SYSTEM_CPUS}"
     case "${QUIET}" in
         0) exec -a "NetBSD ${NETBSD_VERSION} [QEMU${ENABLE_KVM}]" qemu-system-x86_64 ;;


### PR DESCRIPTION
Recent versions of QEMU has removed the "virtio" netdev. Switching to e1000 instead.