### PR TITLE
Specify '-k /etc/skel' on useradd(8) to pull default dot files.

### DIFF
--- a/scripts/system-setup.post.netbsd
+++ b/scripts/system-setup.post.netbsd
@@ -29,6 +29,7 @@ if [ "\${USER_ID}" ] ; then
   /usr/sbin/useradd -d "/home/\${USER_NAME}" \
                     -u "\${USER_ID}" \
                     -G wheel \
+                    -k /etc/skel \
                     -s /usr/pkg/bin/bash \
                     "\${USER_NAME}"
 fi


### PR DESCRIPTION
Otherwise maybe `$PATH` and other enviroments won't set properly.