### PR TITLE
Use correct fs_vfstype for fdesc in fstab(5).

### DIFF
--- a/scripts/system-setup.pre.netbsd
+++ b/scripts/system-setup.pre.netbsd
@@ -26,7 +26,7 @@ cat > etc/fstab <<EOF
 192.168.76.2:/bsd  /        nfs     rw          0  0
 /kern              /kern    kernfs  rw          0  0
 /proc              /proc    procfs  rw          0  0
-fdesc              /dev/fd  fdescfs rw,-o=union 0  0
+fdesc              /dev/fd  fdesc   rw,-o=union 0  0
 ptyfs              /dev/pts ptyfs   rw          0  0
 EOF
 


### PR DESCRIPTION
https://github.com/tsutsui/ibus/actions/runs/4385444129/jobs/7678174039#step:3:400
```
mount: exec mount_fdescfs for /dev/fd: mount_fdescfs: No such file or directory
```